### PR TITLE
Add WiFi event category

### DIFF
--- a/source/EventCategory.cs
+++ b/source/EventCategory.cs
@@ -30,6 +30,10 @@ namespace nanoFramework.Runtime.Events
         /// <summary>
         /// Specifies a Network event.
         /// </summary>
-        Network = 40
+        Network = 40,
+        /// <summary>
+        /// Specifies a WiFi event.
+        /// </summary>
+        WiFi = 50
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add WiFi event category in preparation for Windows.Device.Wifi
Was going to use Network event but Eventsink doesn't support multiple listeners

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- It would be nice if you could sign off your contribution by replacing the name with your GitHub user name and GitHub email contact. -->
Signed-off-by: adriansoundy <adriansoundy@gmail.com>
